### PR TITLE
Override `supports_on_duplicate_key_update?`

### DIFF
--- a/lib/activerecord-import/adapters/sqlserver_adapter.rb
+++ b/lib/activerecord-import/adapters/sqlserver_adapter.rb
@@ -1,6 +1,10 @@
 module ActiveRecord::Import::SQLServerAdapter
   include ActiveRecord::Import::ImportSupport
 
+  def supports_on_duplicate_key_update?
+    false
+  end
+
   def insert_many( sql, values, options = {}, *args )
     base_sql, post_sql = if sql.is_a?( String )
       [sql, '']


### PR DESCRIPTION
`supports_on_duplicate_key_update?` was changed by activerecord-import 1.0.4.
FYI: https://github.com/zdennis/activerecord-import/pull/657

So, I override and set `false` value.
